### PR TITLE
Improve XmlMini date parsing

### DIFF
--- a/activesupport/lib/active_support/xml_mini.rb
+++ b/activesupport/lib/active_support/xml_mini.rb
@@ -62,11 +62,19 @@ module ActiveSupport
       "yaml"     => Proc.new { |yaml| yaml.to_yaml }
     } unless defined?(FORMATTING)
 
+    DATE_REGEX = /\A(\d{4})-(\d{2})-(\d{2})\z/ unless defined?(DATE_REGEX)
+
     # TODO use regexp instead of Date.parse
     unless defined?(PARSING)
       PARSING = {
         "symbol"       => Proc.new { |symbol|  symbol.to_s.to_sym },
-        "date"         => Proc.new { |date|    ::Date.parse(date) },
+        "date"         => Proc.new { |date|
+          if DATE_REGEX.match?(date)
+            ::Date.new($1.to_i, $2.to_i, $3.to_i)
+          else
+            ::Date.parse(date)
+          end
+        },
         "datetime"     => Proc.new { |time|    Time.xmlschema(time).utc rescue ::DateTime.parse(time).utc },
         "duration"     => Proc.new { |duration| Duration.parse(duration) },
         "integer"      => Proc.new { |integer| integer.to_i },


### PR DESCRIPTION
## Summary
- parse strict YYYY-MM-DD dates without falling back to `Date.parse`

## Testing
- `bundle exec rake test TEST=activesupport/test/core_ext/object/to_query_test.rb -n test_array -v` *(fails: `sdoc.git is not yet checked out`)*

------
https://chatgpt.com/codex/tasks/task_e_685c57a2dda483278def0e85c55761f0